### PR TITLE
Add Python challenges to code-challenges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,342 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/database,jupyternotebooks,linux,macos,pycharm+all,python,venv,virtualenv,visualstudiocode,windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=database,jupyternotebooks,linux,macos,pycharm+all,python,venv,virtualenv,visualstudiocode,windows
+
+### Database ###
+*.accdb
+*.db
+*.dbf
+*.mdb
+*.pdb
+*.sqlite3
+
+### JupyterNotebooks ###
+# gitignore template for Jupyter Notebooks
+# website: http://jupyter.org/
+
+.ipynb_checkpoints
+*/.ipynb_checkpoints/*
+
+# IPython
+profile_default/
+ipython_config.py
+
+# Remove previous ipynb_checkpoints
+#   git rm -r .ipynb_checkpoints/
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### PyCharm+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+pytestdebug.log
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+doc/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+
+# IPython
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+### venv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+### VirtualEnv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+
+### VisualStudioCode ###
+.vscode/*
+*.code-workspace
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/database,jupyternotebooks,linux,macos,pycharm+all,python,venv,virtualenv,visualstudiocode,windows

--- a/Add/README.md
+++ b/Add/README.md
@@ -1,0 +1,61 @@
+# Add
+
+You'll need to write a function that accepts two lists-of-lists of numbers and returns one list-of-lists with each of the corresponding numbers in the two given lists-of-lists added together.
+
+It should work something like this:
+
+```python
+>>> matrix1 = [[1, -2], [-3, 4]]
+>>> matrix2 = [[2, -1], [0, -1]]
+>>> add(matrix1, matrix2)
+[[3, -3], [-3, 3]]
+>>> matrix1 = [[1, -2, 3], [-4, 5, -6], [7, -8, 9]]
+>>> matrix2 = [[1, 1, 0], [1, -2, 3], [-2, 2, -2]]
+>>> add(matrix1, matrix2)
+[[2, -1, 3], [-3, 3, -3], [5, -6, 7]]
+```
+
+You should solve this problem using only the standard library (e.g. without using a third-party package like `pandas`).
+
+Before attempting any bonuses, I'd like you to put some effort into figuring out the clearest and most idiomatic way to solve this problem. If you're using indexes to loop, take a look at the first hint.
+
+## Bonus 1
+
+Modify your add function to accept and "add" any number of lists-of-lists. ✔️
+
+```python
+>>> matrix1 = [[1, 9], [7, 3]]
+>>> matrix2 = [[5, -4], [3, 3]]
+>>> matrix3 = [[2, 3], [-3, 1]]
+>>> add(matrix1, matrix2, matrix3)
+[[8, 8], [7, 7]]
+```
+
+## Bonus 2
+
+If the arguments provided to the `add` function are different shapes, raise a `ValueError`.
+
+```python
+>>> add([[1, 9], [7, 3]], [[1, 2], [3]])
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "add.py", line 10, in add
+    raise ValueError("Given matrices are not the same size.")
+ValueError: Given matrices are not the same size.
+```
+
+## Hints
+
+- [How to loop with and without Indexes in Python](http://treyhunner.com/2016/04/how-to-loop-with-indexes-in-python/)
+- [Using tuple unpacking to improve readability](https://treyhunner.com/2018/03/tuple-unpacking-improves-python-code-readability/)
+- [Python List comprehensions](https://treyhunner.com/2015/12/python-list-comprehensions-now-in-color/)
+- [Using `*`'s in Python for packing and unpacking](https://treyhunner.com/2018/10/asterisks-in-python-what-they-are-and-how-to-use-them/#Asterisks_for_packing_arguments_given_to_function)
+- [StackOverflow: Raising an exception in Python](https://stackoverflow.com/questions/2052390/manually-raising-throwing-an-exception-in-python)
+
+## Tests
+
+Change directory in your terminal to the `Add` directory and then run `python -m unittest` to run the tests for this challenge.
+
+Feel free to reference the tests if you have any confusion about the expected behavior of the add function.
+
+Good luck!

--- a/Add/README.md
+++ b/Add/README.md
@@ -56,6 +56,8 @@ ValueError: Given matrices are not the same size.
 
 Change directory in your terminal to the `Add` directory and then run `python -m unittest` to run the tests for this challenge.
 
-Feel free to reference the tests if you have any confusion about the expected behavior of the add function.
+If you'd like to try the bonus challenges, you'll want to comment out the noted lines of code in the test file to test them properly.
+
+Finally, Feel free to reference the tests if you have any confusion about the expected behavior of the add function.
 
 Good luck!

--- a/Add/add.py
+++ b/Add/add.py
@@ -1,0 +1,3 @@
+def add():
+    # **Write your solution below:**
+    pass

--- a/Add/test_add.py
+++ b/Add/test_add.py
@@ -1,0 +1,63 @@
+from copy import deepcopy
+import unittest
+
+from add import add
+
+
+class AddTests(unittest.TestCase):
+
+    """Tests for add."""
+
+    def test_single_items(self):
+        self.assertEqual(add([[5]], [[-2]]), [[3]])
+
+    def test_two_by_two_matrixes(self):
+        m1 = [[6, 6], [3, 1]]
+        m2 = [[1, 2], [3, 4]]
+        m3 = [[7, 8], [6, 5]]
+        self.assertEqual(add(m1, m2), m3)
+
+    def test_two_by_three_matrixes(self):
+        m1 = [[1, 2, 3], [4, 5, 6]]
+        m2 = [[-1, -2, -3], [-4, -5, -6]]
+        m3 = [[0, 0, 0], [0, 0, 0]]
+        self.assertEqual(add(m1, m2), m3)
+
+    def test_input_unchanged(self):
+        m1 = [[6, 6], [3, 1]]
+        m2 = [[1, 2], [3, 4]]
+        m1_original = deepcopy(m1)
+        m2_original = deepcopy(m2)
+        add(m1, m2)
+        self.assertEqual(m1, m1_original)
+        self.assertEqual(m2, m2_original)
+
+    # To test the Bonus part of this exercise, comment out the following line
+    @unittest.expectedFailure
+    def test_any_number_of_matrixes(self):
+        m1 = [[6, 6], [3, 1]]
+        m2 = [[1, 2], [3, 4]]
+        m3 = [[2, 1], [3, 4]]
+        m4 = [[9, 9], [9, 9]]
+        m5 = [[31, 32], [27, 24]]
+        self.assertEqual(add(m1, m2, m3), m4)
+        self.assertEqual(add(m2, m3, m1, m1, m2, m4, m1), m5)
+
+    # To test the Bonus part of this exercise, comment out the following line
+    @unittest.expectedFailure
+    def test_different_matrix_size(self):
+        m1 = [[6, 6], [3, 1]]
+        m2 = [[1, 2], [3, 4], [5, 6]]
+        m3 = [[6, 6], [3, 1, 2]]
+        with self.assertRaises(ValueError):
+            add(m1, m2)
+        with self.assertRaises(ValueError):
+            add(m1, m3)
+        with self.assertRaises(ValueError):
+            add(m1, m1, m1, m3, m1, m1)
+        with self.assertRaises(ValueError):
+            add(m1, m1, m1, m2, m1, m1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Circle/README.md
+++ b/Circle/README.md
@@ -1,0 +1,96 @@
+# Circle
+
+Create a class that represents a circle.
+
+The circle should have a radius, a diameter, and an area. It should also have a nice string representation.
+
+For example:
+
+```python
+>>> c = Circle(5)
+>>> c
+Circle(5)
+>>> c.radius
+5
+>>> c.diameter
+10
+>>> c.area
+78.53981633974483
+```
+
+Additionally the radius should default to 1 if no radius is specified when you create your circle:
+
+```python
+>>> c = Circle()
+>>> c.radius
+1
+>>> c.diameter
+2
+```
+
+Make sure when the radius of your class changes that the diameter and area both automatically update:
+
+```python
+>>> c = Circle(2)
+>>> c.radius = 1
+>>> c.diameter
+2
+>>> c.area
+3.141592653589793
+>>> c
+Circle(1)
+```
+
+You should also be able to set the diameter attribute in your class and have the radius update accordingly.
+
+However, attempting to update the area should raise an `AttributeError`:
+
+```python
+>>> c = Circle(1)
+>>> c.diameter = 4
+>>> c.radius
+2.0
+>>> c.area = 45.678
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "circle.py", line 16, in radius
+AttributeError: can't set attribute
+```
+
+Finally, a Circle's radius cannot be set to a negative number. If it's attempted, you should raise a `ValueError` exception with the error message `"Radius cannot be negative"`.
+
+```python
+>>> c = Circle(5)
+>>> c.radius = 3
+>>> c.radius = -2
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "circle.py", line 27, in radius
+    raise ValueError("Radius cannot be negative")
+ValueError: Radius cannot be negative
+>>> c = Circle (-10)
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "circle.py", line 27, in radius
+    raise ValueError("Radius cannot be negative")
+ValueError: Radius cannot be negative
+```
+
+This means that diameter cannot be negative either (and setting diameter to a negative number should also raise a ValueError).
+
+## Hints
+
+- [Formula and background on computing the area of a circle](https://en.wikipedia.org/wiki/Area_of_a_circle)
+- [Classes and Instances in Python](https://www.youtube.com/watch?v=ZDa-Z5JzLYM/)
+- [Understanding `__str__` and `__repr__`](https://medium.com/swlh/string-representations-in-python-understand-repr-vs-str-12f046986eb5)
+- [Python's `math` module: `math.pi`](https://docs.python.org/3/library/math.html#math.pi)
+- [Making an auto-updating attribute](https://www.youtube.com/watch?v=jCzT9XFZ5bw)
+- [Raising exceptions](https://stackoverflow.com/questions/2052390/manually-raising-throwing-an-exception-in-python)
+
+## Tests
+
+Change directory in your terminal to the `Circle` directory and then run `python -m unittest` to run the tests for this challenge.
+
+Feel free to reference the tests if you have any confusion about the expected behavior of the Circle class.
+
+Good luck!

--- a/Circle/circle.py
+++ b/Circle/circle.py
@@ -1,0 +1,3 @@
+class Circle:
+    # **Write your solution below**
+    pass

--- a/Circle/test_circle.py
+++ b/Circle/test_circle.py
@@ -1,0 +1,97 @@
+import math
+import unittest
+
+from circle import Circle
+
+
+class CircleTests(unittest.TestCase):
+    def test_radius(self):
+        """
+        A circle should take a radius as an argument, and that radius
+        sholud be accessible as an attribute.
+        """
+        circle = Circle(5)
+        self.assertEqual(circle.radius, 5)
+
+    def test_default_radius(self):
+        """
+        If no radius is provided, the radius should default to `1`.
+        """
+        circle = Circle()
+        self.assertEqual(circle.radius, 1)
+
+    def test_diameter(self):
+        """
+        The diameter of a circle should always be the radius of the circle times 2.
+        """
+        circle = Circle(2)
+        self.assertEqual(circle.diameter, 4)
+
+    def test_area(self):
+        """
+        The area of a circle should always be `π * diameter`
+        """
+        circle = Circle(2)
+        self.assertEqual(circle.area, math.pi * 4)
+        circle = Circle(1)
+        self.assertEqual(circle.area, math.pi)
+
+    def test_string_representation(self):
+        """
+        Circle should have a both a `str` representation and a `repr`
+        representation equal to `Circle(radius)`
+        """
+        circle = Circle(2)
+        self.assertEqual(str(circle), "Circle(2)")
+        self.assertEqual(repr(circle), "Circle(2)")
+        circle.radius = 1
+        self.assertEqual(repr(circle), "Circle(1)")
+
+    def test_diameter_and_area_change_based_on_radius(self):
+        """
+        Both the area and the diameter of the circle should update
+        automatically when the radius changes.
+        """
+        circle = Circle(2)
+        self.assertEqual(circle.diameter, 4)
+        circle.radius = 3
+        self.assertEqual(circle.diameter, 6)
+        self.assertEqual(circle.area, math.pi * 9)
+
+    def test_diameter_changeable_but_area_not(self):
+        """
+        The value of diameter should *also* be changable, and should update
+        the radius automatically, but the area should raise an error when a
+        caller attempts to change the value
+        """
+        circle = Circle(2)
+        self.assertEqual(circle.diameter, 4)
+        self.assertEqual(circle.area, math.pi * 4)
+        circle.diameter = 3
+        self.assertEqual(circle.radius, 1.5)
+        with self.assertRaises(AttributeError):
+            circle.area = 3
+
+    def test_no_negative_radius(self):
+        """
+        A `ValueError` exception with the message 'radius cannot be negative'
+        should be raised if a negative number is supplied for the radius.
+        """
+        with self.assertRaises(ValueError) as context:
+            circle = Circle(-2)
+        self.assertEqual(
+            str(context.exception).lower(), "radius cannot be negative",
+        )
+        circle = Circle(2)
+        with self.assertRaises(ValueError) as context:
+            circle.radius = -10
+        self.assertEqual(
+            str(context.exception).lower(), "radius cannot be negative",
+        )
+        with self.assertRaises(ValueError):
+            circle.diameter = -20
+        self.assertEqual(circle.radius, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Compact/README.md
+++ b/Compact/README.md
@@ -1,0 +1,57 @@
+# Compact
+
+Write a function that accepts a sequence (a `list` for example) and returns a new iterable (anything you can loop over) with **adjacent** duplicate values removed.
+
+For example:
+
+```python
+>>> compact([1, 1, 1])
+[1]
+>>> compact([1, 1, 2, 2, 3, 2])
+[1, 2, 3, 2]
+>>> compact([])
+[]
+```
+
+There are two bonuses for this exercise.
+
+I recommend solving the exercise without the bonuses first and then attempting each bonus separately.
+
+## Bonus 1
+
+Refactor the `compact` function to accept any iterable, not just a sequence (which means you can't use index look-ups in your answer).
+
+Here's an example with a generator expression, which is a lazy iterable:
+
+```python
+>>> compact(n**2 for n in [1, 2, 2])
+[1, 4]
+```
+
+## Bonus 2
+
+Refactor the `compact` function once more to return an iterator instead of a `list`.
+
+```python
+>>> c = compact(n**2 for n in [1, 2, 2])
+>>> iter(c) is c
+True
+```
+
+This should allow your compact function to accept iterables that are theoretically infinite in length (or other lazy iterables).
+
+## Hints
+
+- [The Pythonic way to loop with indexes in Python (i.e. _stop using `range`_)](https://treyhunner.com/2016/04/how-to-loop-with-indexes-in-python/)
+- [How to create iterators in Python](https://treyhunner.com/2018/06/how-to-make-an-iterator-in-python/)
+- [**Only read this if you've completed the challenge + bonuses**: An interesting solution using the standard library](https://stackoverflow.com/questions/41511555/fast-removal-of-consecutive-duplicates-in-a-list-and-corresponding-items-from-an/41511571#41511571)
+
+## Tests
+
+Change directory in your terminal to the `Compact` directory and then run `python -m unittest` to run the tests for this challenge.
+
+If you'd like to try the bonus challenges, you'll want to comment out the noted lines of code in the test file to test them properly.
+
+Finally, Feel free to reference the tests if you have any confusion about the expected behavior of the add function.
+
+Good luck!

--- a/Compact/compact.py
+++ b/Compact/compact.py
@@ -1,0 +1,3 @@
+def compact():
+    # **Write your solution here**
+    pass

--- a/Compact/test_compact.py
+++ b/Compact/test_compact.py
@@ -1,0 +1,58 @@
+import unittest
+
+
+from compact import compact
+
+
+class CompactTests(unittest.TestCase):
+    def assertIterableEqual(self, iterable1, iterable2):
+        self.assertEqual(list(iterable1), list(iterable2))
+
+    def test_no_duplicates(self):
+        self.assertIterableEqual(compact([1, 2, 3]), [1, 2, 3])
+
+    def test_adjacent_duplicates(self):
+        self.assertIterableEqual(compact([1, 1, 2, 2, 3]), [1, 2, 3])
+
+    def test_non_adjacent_duplicates(self):
+        self.assertIterableEqual(compact([1, 2, 3, 1, 2]), [1, 2, 3, 1, 2])
+
+    def test_lots_of_adjacent_duplicates(self):
+        self.assertIterableEqual(compact([1, 1, 1, 1, 1, 1]), [1])
+
+    def test_empty_values(self):
+        self.assertIterableEqual(compact([None, 0, "", []]), [None, 0, "", []])
+
+    def test_empty_list(self):
+        self.assertIterableEqual(compact([]), [])
+
+    # To test the Bonus part of this exercise, comment out the following line
+    @unittest.expectedFailure
+    def test_accepts_iterator(self):
+        nums = (n ** 2 for n in [1, 2, 3])
+        self.assertIterableEqual(compact(nums), [1, 4, 9])
+
+    # To test the Bonus part of this exercise, comment out the following line
+    @unittest.expectedFailure
+    def test_returns_iterator(self):
+        nums = (n ** 2 for n in [1, 2, 3])
+        output = compact(nums)
+
+        self.assertEqual(iter(output), iter(output))
+        self.assertEqual(next(output), 1)
+
+        # The below line tests that the incoming iterator isn't exhausted.
+        # It may look odd to test the squares input, but this is correct
+        # because after 1 item has been consumed from the compact
+        # iterator, nums should only have 1 item consumed as well
+        self.assertEqual(next(nums), 4)
+
+        # A more extreme example: calling compact with an infinite iterator
+        from itertools import count
+
+        tens = compact(round(n, -1) for n in count())
+        self.assertEqual([next(tens) for _ in range(3)], [0, 10, 20])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/FixCsv/README.md
+++ b/FixCsv/README.md
@@ -1,0 +1,79 @@
+# Fix CSVs
+
+You're going to write a basic command line program to normalize CSV files, named `fix_csv.py`. The CLI will turn a pipe-delimited file into a comma-delimited file. You'll see how that will work below.
+
+An original, pipe-delimited file would look something like this:
+
+```csv
+Reading|Make|Model|Type|Value
+Reading 0|Toyota|Previa|distance|19.83942
+Reading 1|Dodge|Intrepid|distance|31.28257
+```
+
+And you would run that file through your command-line program typing this in your terminal:
+
+```shell
+python fix_csv.py cars-original.csv cars.csv
+```
+
+As you can see above, `fix_csv.py` takes the path of the pipe-delimited file as its first argument, and the path to the location you'd like your fixed file to be created as the second argument.
+
+Your fixed file should then look like this:
+
+```csv
+Reading,Make,Model,Type,Value
+Reading 0,Toyota,Previa,distance,19.83942
+Reading 1,Dodge,Intrepid,distance,31.28257
+```
+
+Some important things to note:
+- It's valid for a comma to be in your input data, but you'll need to surround data cells with commas in them by double quotes when writing your output file.
+- It's also valid for a quote character to be in your input (you'll need to double up quotes because [that's how CSV escaping works](https://stackoverflow.com/questions/17808511/properly-escape-a-double-quote-in-csv).
+
+See the hints if you need help working with CSV files in Python.
+
+## Bonus 1
+
+Now that you've passed MVP, refactor your program to allow the input delimiter and quote character (`"`) by default) to be optionally specified.
+
+For example any of these should work (all specify input delimiter as pipe and the last two additionally specifies the quote character as single quote):
+
+```shell
+$ python fix_csv.py --in-delimiter="|" cars.csv cars-fixed.csv
+$ python fix_csv.py cars.csv cars-fixed.csv --in-delimiter="|"
+$ python fix_csv.py --in-delimiter="|" --in-quote="'" cars.csv cars-fixed.csv
+$ python fix_csv.py --in-quote="|" --in-delimiter="," cars.csv cars-fixed.csv
+```
+
+To do this, you'll need to look into parsing command-line arguments with Python. There are some standard library modules that can help you out with this. There are 3 different solutions in the standard library actually, but only one I'd recommend.
+
+Once again, avoid `pip install`-ing anything to complete this challenge. These challenges are meant to increase your understanding of Python itself.
+
+Be sure to really read the docs on [Python's CSV module](https://docs.python.org/3/library/csv.html), or you might end up re-implementing a lot of functionality that Python gives you for free.
+
+## Bonus 2
+
+Try to automatically detect the delimiter if an in-delimiter value isn't supplied (don't assume it's pipe and quote, try to get your program to intelligently figure it out).
+
+This is a bit trickier and your solution will likely not work correctly for all files. Definitely check the hints on this one if you get stuck.
+
+## Hints
+
+- [Using `sys.argv` to access command line arguments](https://stackoverflow.com/a/35421024/2633215)
+- [Example usage of the `csv` module in the standard library](https://pymotw.com/3/csv/index.html)
+- [Corey Shafer's short `csv` module tutorial](https://www.youtube.com/watch?v=q5uM4VKywbA)
+- [Restricting the number of command line arguments with multiple assignment](https://treyhunner.com/2018/03/tuple-unpacking-improves-python-code-readability/#Multiple_assignment_is_very_strict)
+- [Using `argparse` to parse command line arguments and flags](http://zetcode.com/python/argparse/)
+- [This could be useful to intelligently figure out how to parse a csv file...](https://docs.python.org/3/library/csv.html#csv.Sniffer)
+
+## Tests
+
+Change directory in your terminal to the `FixCsv` directory and then run `python -m unittest` to run the tests for this challenge.
+
+You'll notice that there are no CSV files in this directory, and that's on purpose. If you examine the tests, you'll see that I'm generating files when you run the tests and then cleaning them up afterwards.
+
+You're welcome to create your own test CSV files if you want to run it yourself with your own data, but the test file itself should be enough to run your solution through its paces.
+
+Finally, if you'd like to try the bonus challenges, you'll want to comment out the noted lines of code in the test file to test them properly.
+
+Good luck!

--- a/FixCsv/fix_csv.py
+++ b/FixCsv/fix_csv.py
@@ -1,0 +1,1 @@
+# **Write your solution below**

--- a/FixCsv/test_fix_csv.py
+++ b/FixCsv/test_fix_csv.py
@@ -1,0 +1,242 @@
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from io import StringIO
+from importlib.machinery import SourceFileLoader
+import os
+import sys
+import warnings
+import shlex
+from textwrap import dedent
+from tempfile import NamedTemporaryFile
+import unittest
+
+
+class FixCSVTests(unittest.TestCase):
+    maxDiff = None
+
+    def test_pipe_file_to_csv_file(self):
+        old_contents = dedent(
+            """
+            2012|Lexus|LFA
+            2009|GMC|Yukon XL 1500
+            1965|Ford|Mustang
+            2005|Hyundai|Sonata
+            1995|Mercedes-Benz|C-Class
+        """
+        ).lstrip()
+
+        expected = dedent(
+            """
+            2012,Lexus,LFA
+            2009,GMC,Yukon XL 1500
+            1965,Ford,Mustang
+            2005,Hyundai,Sonata
+            1995,Mercedes-Benz,C-Class
+        """
+        ).lstrip()
+
+        with make_file(old_contents) as old, make_file("") as new:
+            output = run_program(f"fix_csv.py {old} {new}")
+            with open(new) as new_file:
+                new_contents = new_file.read()
+
+        self.assertEqual(expected, new_contents)
+        self.assertEqual("", output)
+
+    def test_delimiter_in_output(self):
+        old_contents = dedent(
+            """
+            02|Waylon Jennings|Honky Tonk Heroes (Like Me)
+            04|Kris Kristofferson|To Beat The Devil
+            11|Johnny Cash|Folsom Prison Blues
+            13|Billy Joe Shaver|Low Down Freedom
+            21|Hank Williams III|Mississippi Mud
+            22|David Allan Coe|Willie, Waylon, And Me
+            24|Bob Dylan|House Of The Risin' Sun
+        """
+        ).lstrip()
+
+        expected = dedent(
+            """
+            02,Waylon Jennings,Honky Tonk Heroes (Like Me)
+            04,Kris Kristofferson,To Beat The Devil
+            11,Johnny Cash,Folsom Prison Blues
+            13,Billy Joe Shaver,Low Down Freedom
+            21,Hank Williams III,Mississippi Mud
+            22,David Allan Coe,"Willie, Waylon, And Me"
+            24,Bob Dylan,House Of The Risin' Sun
+        """
+        ).lstrip()
+
+        with make_file(old_contents) as old, make_file("") as new:
+            output = run_program(f"fix_csv.py {old} {new}")
+            with open(new) as new_file:
+                new_contents = new_file.read()
+
+        self.assertEqual(expected, new_contents)
+        self.assertEqual("", output)
+
+    def test_original_file_is_unchanged(self):
+        old_contents = dedent(
+            """
+            2012|Lexus|LFA
+            2009|GMC|Yukon XL 1500
+        """
+        ).lstrip()
+
+        with make_file(old_contents) as old, make_file("") as new:
+            run_program(f"fix_csv.py {old} {new}")
+            with open(old) as old_file:
+                contents = old_file.read()
+
+        self.assertEqual(old_contents, contents)
+
+    def test_call_with_too_many_files(self):
+        with make_file("") as old, make_file("") as new:
+            with self.assertRaises(BaseException):
+                run_program(f"fix_csv.py {old} {new} {old}")
+
+    # To test the Bonus part of this exercise, comment out the following line
+    @unittest.expectedFailure
+    def test_in_delimiter_and_in_quote(self):
+        old_contents = dedent(
+            """
+            2012 Lexus "LFA"
+            2009 GMC 'Yukon XL 1500'
+            1995 "Mercedes-Benz" C-Class
+        """
+        ).lstrip()
+
+        expected1 = dedent(
+            """
+            2012,Lexus,LFA
+            2009,GMC,'Yukon,XL,1500'
+            1995,Mercedes-Benz,C-Class
+        """
+        ).lstrip()
+
+        expected2 = dedent(
+            '''
+            2012,Lexus,"""LFA"""
+            2009,GMC,Yukon XL 1500
+            1995,"""Mercedes-Benz""",C-Class
+        '''
+        ).lstrip()
+
+        with make_file(old_contents) as old, make_file("") as new:
+            run_program(f'fix_csv.py {old} {new} --in-delimiter=" "')
+            with open(new) as new_file:
+                self.assertEqual(expected1, new_file.read())
+
+            run_program(f"""fix_csv.py --in-delimiter=" " --in-quote="'" {old} {new}""")
+            with open(new) as new_file:
+                self.assertEqual(expected2, new_file.read())
+
+    # To test the Bonus part of this exercise, comment out the following line
+    @unittest.expectedFailure
+    def test_autodetect_input_format(self):
+        contents1 = dedent(
+            """
+            '2012' 'Lexus' 'LFA'
+            '2009' 'GMC' 'Yukon XL 1500'
+            '1995' 'Mercedes-Benz' 'C-Class'
+        """
+        ).lstrip()
+
+        expected1 = dedent(
+            """
+            2012,Lexus,LFA
+            2009,GMC,Yukon XL 1500
+            1995,Mercedes-Benz,C-Class
+        """
+        ).lstrip()
+
+        with make_file(contents1) as old, make_file("") as new:
+            run_program(f"fix_csv.py {old} {new}")
+            with open(new) as new_file:
+                self.assertEqual(expected1, new_file.read())
+
+        contents2 = dedent(
+            """
+            "02"\t"Waylon Jennings"\t"Honky Tonk Heroes (Like Me)"\t"3:29"
+            "04"\t"Kris Kristofferson"\t"To Beat The Devil"\t"4:05"
+            "11"\t"Johnny Cash"\t"Folsom Prison Blues"\t"2:51"
+            "13"\t"Billy Joe Shaver"\t"Low Down Freedom"\t"2:53"
+            "21"\t"Hank Williams III"\t"Mississippi Mud"\t"3:32"
+            "22"\t"David Allan Coe"\t"Willie, Waylon, And Me"\t"3:24"
+            "24"\t"Bob Dylan"\t"House Of The Risin' Sun"\t"5:20"
+        """
+        ).lstrip()
+
+        expected2 = dedent(
+            """
+            02,Waylon Jennings,Honky Tonk Heroes (Like Me),3:29
+            04,Kris Kristofferson,To Beat The Devil,4:05
+            11,Johnny Cash,Folsom Prison Blues,2:51
+            13,Billy Joe Shaver,Low Down Freedom,2:53
+            21,Hank Williams III,Mississippi Mud,3:32
+            22,David Allan Coe,"Willie, Waylon, And Me",3:24
+            24,Bob Dylan,House Of The Risin' Sun,5:20
+        """
+        ).lstrip()
+
+        with make_file(contents2) as old, make_file("") as new:
+            run_program(f"fix_csv.py {old} {new}")
+            with open(new) as new_file:
+                self.assertEqual(expected2, new_file.read())
+
+
+class DummyException(Exception):
+    """No code will ever raise this exception."""
+
+
+def run_program(arguments="", raises=DummyException):
+    """
+    Run program at given path with given arguments.
+
+    If raises is specified, ensure the given exception is raised.
+    """
+    arguments = arguments.replace("\\", "\\\\")
+    path, *args = shlex.split(arguments)
+    old_args = sys.argv
+    warnings.simplefilter("ignore", ResourceWarning)
+
+    try:
+        sys.argv = [path] + args
+
+        try:
+            if "__main__" in sys.modules:
+                del sys.modules["__main__"]
+
+            with redirect_stdout(StringIO()) as output:
+                with redirect_stderr(output):
+                    SourceFileLoader("__main__", path).load_module()
+        except raises:
+            return output.getvalue()
+        except SystemExit as e:
+            if e.args != (0,):
+                raise SystemExit(output.getvalue()) from e
+        finally:
+            sys.modules.pop("__main__", None)
+
+        if raises is not DummyException:
+            raise AssertionError("{} not raised".format(raises))
+
+        return output.getvalue()
+    finally:
+        sys.argv = old_args
+
+
+@contextmanager
+def make_file(contents=None):
+    """Context manager providing name of a file containing given contents."""
+    with NamedTemporaryFile(mode="wt", encoding="utf-8", delete=False) as f:
+        if contents:
+            f.write(contents)
+    try:
+        yield f.name
+    finally:
+        os.remove(f.name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
I'll be using this PR to add a bunch of challenges to the repository.

They'll be varying in difficulty, and will each have their own README meant to both explain the challenge and also provide helpful resources to keep you from getting stuck.

Some will have bonus challenges, all of them will have tests using the `unittest` module to ensure you only need Python to run things.

Think of these challenges less as a "if you know how to do these you'll get a job at Google" and more like "These challenges should _greatly_ increase your depth of understanding of Python and Pythonic code".